### PR TITLE
Syntax highlighting for preprocessor conditional compilation directives

### DIFF
--- a/Syntaxes/MQL4.tmLanguage
+++ b/Syntaxes/MQL4.tmLanguage
@@ -34,7 +34,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>#\b(property|import|define|include)\b</string>
+			<string>#\b(property|import|define|include|ifdef|ifndef|else|endif)\b</string>
 			<key>name</key>
 			<string>keyword.control.preprocessor.mql4</string>
 		</dict>


### PR DESCRIPTION
There are preprocessor conditional compilation directives that allow compiling or skipping a part of the program depending on the fulfillment of a certain condition.

Those directives are:
`#ifdef, #ifndef, #else, #endif`

This patch provides syntax highlighting support for them.