### PR TITLE
Syntax highlighting for the definition of a separate destructor body

### DIFF
--- a/Syntaxes/MQL4.tmLanguage
+++ b/Syntaxes/MQL4.tmLanguage
@@ -215,7 +215,7 @@
     		)
     		(\s*) (?!(while|for|do|if|else|switch|catch|return)\s*\()
     		(
-    			(?: [A-Za-z_][A-Za-z0-9_]*+ | :: )++ |                  # actual name
+    			(?: [A-Za-z_][A-Za-z0-9_]*+ | ::~? )++ |                  # actual name
     			(?: (?&lt;=operator) (?: [-*&amp;&lt;&gt;=+!]+ | \(\) | \[\] ) )  # if it is a C++ operator
     		)
     		 \s*(?=\()</string>


### PR DESCRIPTION
To define a destructor we need to add the ~ symbol in front of the destructor's name.
This patch provides syntax highlighting for destructors bodies that are defined outside the header off the class.

E.g. 

    class Example()
    {
        public:
            Example();
            ~Example();
    }

    void Classname::~Classname() 
    {
        // Do destructor stuff here
    }

The patch applies to the `::~` part of `void Classname::~Classname()` at line 8.