### PR TITLE
Highlight .mq5 files

### DIFF
--- a/Syntaxes/MQL4.tmLanguage
+++ b/Syntaxes/MQL4.tmLanguage
@@ -6,6 +6,7 @@
 	<array>
 		<string>mql4</string>
 		<string>mq4</string>
+		<string>mq5</string>
 		<string>mqh</string>
 	</array>
 	<key>foldingStartMarker</key>


### PR DESCRIPTION
This grammar works pretty well for MQL5 files too: [example in Lightshow](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fgithub.com%2Fcurrencysecrets%2Fmql4%2Fblob%2Fmaster%2FSyntaxes%2FMQL4.tmLanguage&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fgithub.com%2Fosorgin%2Flinguist%2Fblob%2F9945d301be8dca477f575c16166fb5ed43616441%2Fsamples%2FMQL5%2Findicator-sample.mq5&code=). Thus, this pull request adds `.mq5` to the list of file extensions.
