### PR TITLE
Invalid XML Syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .DS_Store
 */.DS_Store
+
+# Visual Studio 2015/2017 cache/options directory
+.vs/

--- a/Syntaxes/MQL4.tmLanguage
+++ b/Syntaxes/MQL4.tmLanguage
@@ -337,7 +337,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?x) (?x) (?: (?: (?= \s ) (?&lt;!else|new|return) (?&lt;=\w)\s+ ) ) ( (?: [A-Za-z_][A-Za-z0-9_]*+ | :: )++ | (?: (?&lt;=operator) (?: [-*&&lt;&gt;=+!]+ | \(\) | \[\] ) )? ) \s*(\()</string>
+					<string>(?x) (?x) (?: (?: (?= \s ) (?&lt;!else|new|return) (?&lt;=\w)\s+ ) ) ( (?: [A-Za-z_][A-Za-z0-9_]*+ | :: )++ | (?: (?&lt;=operator) (?: [-*&lt;&gt;=+!]+ | \(\) | \[\] ) )? ) \s*(\()</string>
 					<key>name</key>
 					<string>meta.initialization.mql4</string>
 				</dict>


### PR DESCRIPTION
Syntaxes/MQL4.tmLanguage had an XML syntax error that prevented it from being used for syntax highlighting in Visual Studio 2019.

Also when opening this repo Visual Studio 2019 it is necessary to ignore the .vs directory.